### PR TITLE
Matt/193 git tooling

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+## Status
+_Use labels (`review needed`, `in progress`, or `paused`) to declare status_
+
+#### What does this PR do?
+A few sentences describing the overall goals of the pull request's commits.
+Why are we making these changes? Is there more work to be done to fully
+achieve these goals?
+
+#### Helpful background context (if appropriate)
+
+#### How can a reviewer manually see the effects of these changes?
+
+#### What are the relevant tickets?
+- https://mitlibraries.atlassian.net/browse/NTI-
+
+#### Screenshots (if appropriate)
+
+#### Todo:
+- [ ] Documentation
+- [ ] Stakeholder approval
+
+#### Requires new or updated plugins, themes, or libraries?
+YES | NO
+
+#### Requires change to deploy process?
+YES | NO

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,15 +4,18 @@
 # For use with the MIT Libraries' analytics plugin.
 # @link https://github.com/MITLibraries/mitlib-analytics
 
+# Declare what Travis environment should be used. Specifically, we need the
+# 'precise' environment rather than 'trusty' to get PHP 5.3.
+dist: precise
+
 # Declare project language.
 # @link http://about.travis-ci.org/docs/user/languages/php/
 language: php
 
 # Declare versions of PHP to use. Use one decimal max.
 php:
-php:
   # aliased to a recent 7.1.x version
-  - "7.1"
+  - "7.2"
   # aliased to a recent 5.6.x version
   - "5.6"
   # aliased to a recent 5.3.x version
@@ -25,17 +28,17 @@ env:
   # @link https://github.com/WordPress/WordPress
   # WP_VERSION=master WP_MULTISITE=0
   - WP_VERSION=master WP_MULTISITE=1
-  # WordPress 4.7
-  # @link https://github.com/WordPress/WordPress/tree/4.7-branch
-  # WP_VERSION=4.7 WP_MULTISITE=0
-  - WP_VERSION=4.7 WP_MULTISITE=1
+  # WordPress 4.9
+  # @link https://github.com/WordPress/WordPress/tree/4.9-branch
+  # WP_VERSION=4.9 WP_MULTISITE=0
+  - WP_VERSION=4.9 WP_MULTISITE=1
 
 # Declare "future" releases to be acceptable failures.
 # @link https://buddypress.trac.wordpress.org/ticket/5620
 # @link http://docs.travis-ci.com/user/build-configuration/
 matrix:
   allow_failures:
-    - php: "7.1"
+    - php: "7.2"
     - php: "5.6"
     - env: WP_VERSION=master WP_MULTISITE=1
   fast_finish: true


### PR DESCRIPTION
## Status
_Use labels (`review needed`, `in progress`, or `paused`) to declare status_

#### What does this PR do?
This adds the PR template text that we've adopted elsewhere. It also updates the Travis configuration, to update version numbers and specify an environment that has PHP 5.3 available.

#### How can a reviewer manually see the effects of these changes?
This is solely a tooling update - no deployed changes will be visible. The PR template will be in effect after this merges, but the Travis report even on this PR should use PHP 7.2 (with failures allowed), WordPress 4.9, and the Precise environment.

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/NTI-193

#### Requires new or updated plugins, themes, or libraries?
NO

#### Requires change to deploy process?
NO
